### PR TITLE
Add WebGL Mandelbrot explorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Install the dependencies with:
 pip install numpy matplotlib
 ```
 
-## Usage
+## Usage (Python)
 
 Run the script with:
 
@@ -22,6 +22,8 @@ Run the script with:
 python mandelbrot_zoom.py
 ```
 
-An interactive window will open. Drag with the left mouse button to draw a rectangle and zoom in on that region of the Mandelbrot set.
-You can also use the mouse scroll wheel to zoom in and out around the cursor
-position and drag with the right mouse button to pan around the current view.
+An interactive window will open. Drag with the left mouse button to draw a rectangle and zoom in on that region of the Mandelbrot set. You can also use the mouse scroll wheel to zoom in and out around the cursor position and drag with the right mouse button to pan around the current view.
+
+## WebGL Explorer
+
+A browser-based explorer is available using WebGL for fast rendering. Open `index.html` in a modern browser. Use the sliders to adjust the number of iterations and color shift. Click and drag to pan and use the mouse wheel to zoom.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Mandelbrot Explorer</title>
+  <style>
+    body { margin: 0; font-family: sans-serif; display: flex; flex-direction: column; align-items: center; }
+    #controls { margin: 10px; display: flex; gap: 10px; align-items: center; }
+    #glCanvas { width: 800px; height: 800px; border: 1px solid #ccc; }
+  </style>
+</head>
+<body>
+  <h1>Mandelbrot Explorer (WebGL)</h1>
+  <div id="controls">
+    <label>Iterations <input id="iter" type="range" min="50" max="1000" value="200"></label>
+    <label>Color Shift <input id="color" type="range" min="0" max="360" value="0"></label>
+  </div>
+  <canvas id="glCanvas" width="800" height="800"></canvas>
+  <script src="mandelbrot.js"></script>
+</body>
+</html>

--- a/mandelbrot.js
+++ b/mandelbrot.js
@@ -1,0 +1,144 @@
+const canvas = document.getElementById('glCanvas');
+const gl = canvas.getContext('webgl');
+if (!gl) {
+  alert('WebGL not supported');
+}
+
+function createShader(gl, type, src) {
+  const shader = gl.createShader(type);
+  gl.shaderSource(shader, src);
+  gl.compileShader(shader);
+  if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+    console.error(gl.getShaderInfoLog(shader));
+    gl.deleteShader(shader);
+    return null;
+  }
+  return shader;
+}
+
+function createProgram(gl, vsSrc, fsSrc) {
+  const program = gl.createProgram();
+  gl.attachShader(program, createShader(gl, gl.VERTEX_SHADER, vsSrc));
+  gl.attachShader(program, createShader(gl, gl.FRAGMENT_SHADER, fsSrc));
+  gl.linkProgram(program);
+  if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+    console.error(gl.getProgramInfoLog(program));
+    return null;
+  }
+  return program;
+}
+
+const vertexSrc = `
+attribute vec2 position;
+void main() {
+  gl_Position = vec4(position, 0.0, 1.0);
+}`;
+
+const fragmentSrc = `
+precision highp float;
+uniform vec2 u_center;
+uniform float u_scale;
+uniform vec2 u_resolution;
+uniform int u_iter;
+uniform float u_color;
+
+vec3 hsv2rgb(vec3 c) {
+    vec4 K = vec4(1.0, 2.0/3.0, 1.0/3.0, 3.0);
+    vec3 p = abs(fract(c.xxx + K.xyz) * 6.0 - K.www);
+    return c.z * mix(K.xxx, clamp(p - K.xxx, 0.0, 1.0), c.y);
+}
+
+void main() {
+    vec2 uv = (gl_FragCoord.xy / u_resolution - 0.5) * u_scale;
+    vec2 c = uv + u_center;
+    vec2 z = vec2(0.0);
+    int i;
+    for (i = 0; i < 1000; i++) {
+        if (i >= u_iter || dot(z, z) > 4.0) break;
+        z = vec2(z.x*z.x - z.y*z.y, 2.0*z.x*z.y) + c;
+    }
+    float f = float(i) / float(u_iter);
+    vec3 col = hsv2rgb(vec3(u_color + f, 1.0, f < 1.0 ? 1.0 : 0.0));
+    gl_FragColor = vec4(col, 1.0);
+}`;
+
+const program = createProgram(gl, vertexSrc, fragmentSrc);
+
+const positionLoc = gl.getAttribLocation(program, 'position');
+const centerLoc = gl.getUniformLocation(program, 'u_center');
+const scaleLoc = gl.getUniformLocation(program, 'u_scale');
+const resLoc = gl.getUniformLocation(program, 'u_resolution');
+const iterLoc = gl.getUniformLocation(program, 'u_iter');
+const colorLoc = gl.getUniformLocation(program, 'u_color');
+
+const buffer = gl.createBuffer();
+gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+const vertices = new Float32Array([
+  -1, -1,
+   1, -1,
+  -1,  1,
+  -1,  1,
+   1, -1,
+   1,  1
+]);
+
+gl.bufferData(gl.ARRAY_BUFFER, vertices, gl.STATIC_DRAW);
+
+gl.useProgram(program);
+
+gl.enableVertexAttribArray(positionLoc);
+gl.vertexAttribPointer(positionLoc, 2, gl.FLOAT, false, 0, 0);
+
+gl.uniform2f(resLoc, canvas.width, canvas.height);
+
+let center = {x: -0.5, y: 0};
+let scale = 3.0;
+let iterInput = document.getElementById('iter');
+let colorInput = document.getElementById('color');
+let iterations = parseInt(iterInput.value);
+let colorShift = parseFloat(colorInput.value) / 360.0;
+
+iterInput.oninput = () => {
+  iterations = parseInt(iterInput.value);
+};
+colorInput.oninput = () => {
+  colorShift = parseFloat(colorInput.value) / 360.0;
+};
+
+let dragging = false;
+let lastX = 0;
+let lastY = 0;
+
+canvas.addEventListener('mousedown', (e) => {
+  dragging = true;
+  lastX = e.clientX;
+  lastY = e.clientY;
+});
+canvas.addEventListener('mousemove', (e) => {
+  if (!dragging) return;
+  const dx = e.clientX - lastX;
+  const dy = e.clientY - lastY;
+  const factor = scale / canvas.height;
+  center.x -= dx * factor;
+  center.y += dy * factor;
+  lastX = e.clientX;
+  lastY = e.clientY;
+});
+window.addEventListener('mouseup', () => { dragging = false; });
+
+canvas.addEventListener('wheel', (e) => {
+  e.preventDefault();
+  const zoom = e.deltaY > 0 ? 1.1 : 0.9;
+  scale *= zoom;
+});
+
+function render() {
+  gl.uniform2f(centerLoc, center.x, center.y);
+  gl.uniform1f(scaleLoc, scale);
+  gl.uniform1i(iterLoc, iterations);
+  gl.uniform1f(colorLoc, colorShift);
+  gl.drawArrays(gl.TRIANGLES, 0, 6);
+  requestAnimationFrame(render);
+}
+
+render();


### PR DESCRIPTION
## Summary
- add `index.html` with controls for WebGL Mandelbrot explorer
- add `mandelbrot.js` implementing fragment shader rendering, slider controls, and mouse interactions
- update README with instructions for the new WebGL explorer

## Testing
- `python mandelbrot_zoom.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_683f6bcb9ff88328a45954815c783778