### PR TITLE
Fix WebGL shader compile error

### DIFF
--- a/mandelbrot.js
+++ b/mandelbrot.js
@@ -52,8 +52,8 @@ void main() {
     vec2 uv = (gl_FragCoord.xy / u_resolution - 0.5) * u_scale;
     vec2 c = uv + u_center;
     vec2 z = vec2(0.0);
-    int i;
-    for (i = 0; i < 1000; i++) {
+    int i = 0;
+    for (; i < 1000; i++) {
         if (i >= u_iter || dot(z, z) > 4.0) break;
         z = vec2(z.x*z.x - z.y*z.y, 2.0*z.x*z.y) + c;
     }


### PR DESCRIPTION
## Summary
- fix fragment shader loop initialization to avoid WebGL compile error

## Testing
- `glslangValidator -S frag frag3.glsl`

------
https://chatgpt.com/codex/tasks/task_e_683f6e913f5483288f447ac0e6680c2a